### PR TITLE
Create .scala-steward.conf

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,4 @@
+updates.ignore = [
+  # These will be merged forward from series/0.23
+  { groupId = "org.http4s", artifactId = "sbt-http4s-org" }
+]


### PR DESCRIPTION
We're about to get scala-steward requests on series/0.23.  Most upgrades will originate there, and should be merged from that branch to main.  This will prevent getting two of everything.