### PR TITLE
Fix http4s version update by also updating scala version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.10, 3.2.1]
+        scala: [2.13.10, 3.3.0]
         java: [temurin@8, temurin@11, temurin@17]
         exclude:
-          - scala: 3.2.1
+          - scala: 3.3.0
             java: temurin@11
-          - scala: 3.2.1
+          - scala: 3.3.0
             java: temurin@17
     runs-on: ${{ matrix.os }}
     steps:
@@ -230,12 +230,12 @@ jobs:
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (3.2.1)
+      - name: Download target directories (3.3.0)
         uses: actions/download-artifact@v3
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-3.2.1
+          name: target-${{ matrix.os }}-${{ matrix.java }}-3.3.0
 
-      - name: Inflate target directories (3.2.1)
+      - name: Inflate target directories (3.3.0)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ ThisBuild / developers := List(
 )
 
 val Scala213 = "2.13.10"
-ThisBuild / crossScalaVersions := Seq(Scala213, "3.2.1")
+ThisBuild / crossScalaVersions := Seq(Scala213, "3.3.0")
 ThisBuild / scalaVersion := Scala213
 
 lazy val root = project.in(file(".")).aggregate(twirl).enablePlugins(NoPublishPlugin)


### PR DESCRIPTION
Many current pull request with version updates fail, because http4s-core is built with newer scala3 version.
This PR updates the scala3 version in the project, so other PRs can be successfully built and merged